### PR TITLE
fix syntax of sumToN

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ G2Q allows constraint programming, via writing Haskell predicates.
 A quasiquoter, g2, is provided which can take concrete arguments at runtime, and solve for unknown symbolic arguments.
 
 For example, to find inputs from a list xs which sum to a given number n, you can write:
-```  
+```hs
 sumToN :: Int -> [Int] -> IO (Maybe [Int])
-sumToN = [g2| \(n :: Int) (xs :: [Int]) ->
-              ?(ys :: [Int])
+sumToN = [g2| \(n :: Int) (xs :: [Int]) -> ?(ys :: [Int])
             |  sum ys == n
             && all (\e -> e `elem` xs) ys
             && length ys >= 1 |]


### PR DESCRIPTION
There's a parse error with `?(ys :: [Int])` placed on the second line.

A solution is to move it to the first line, with a space before `?`.

(Looks like the parser can be improved to fix this fully.)